### PR TITLE
[SprintFoundry] AgentSandbox unattended workflow smoke 2026-03-19

### DIFF
--- a/kind-workflow-smoke.txt
+++ b/kind-workflow-smoke.txt
@@ -1,2 +1,2 @@
 linear workflow kind smoke
-spr-8 agentsandbox unattended workflow smoke 2026-03-19 signature-retry 2026-03-19T15:58Z
+spr-8 agentsandbox unattended workflow smoke 2026-03-19 signature-retry 2026-03-19T16:01Z

--- a/kind-workflow-smoke.txt
+++ b/kind-workflow-smoke.txt
@@ -1,1 +1,2 @@
 linear workflow kind smoke
+spr-8 agentsandbox unattended workflow smoke 2026-03-19 signature-retry 2026-03-19T15:58Z

--- a/tests/workflow-smoke.qa.sh
+++ b/tests/workflow-smoke.qa.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pass=0
+fail=0
+
+check_contains() {
+  local file="$1"
+  local pattern="$2"
+  local name="$3"
+  if grep -Fq "$pattern" "$file"; then
+    echo "PASS: $name"
+    pass=$((pass+1))
+  else
+    echo "FAIL: $name"
+    fail=$((fail+1))
+  fi
+}
+
+check_nonempty() {
+  local file="$1"
+  local name="$2"
+  if [ -s "$file" ]; then
+    echo "PASS: $name"
+    pass=$((pass+1))
+  else
+    echo "FAIL: $name"
+    fail=$((fail+1))
+  fi
+}
+
+check_contains "kind-workflow-smoke.txt" "spr-8 agentsandbox unattended workflow smoke 2026-03-19" "Kind smoke marker includes SPR-8 signature"
+check_contains "kind-workflow-smoke.txt" "signature-retry 2026-03-19T16:01Z" "Kind smoke marker includes required QA webhook retry timestamp"
+check_nonempty "linear-live-workflow-smoke.txt" "Linear live workflow smoke marker file is non-empty"
+
+printf '{"total":%d,"passed":%d,"failed":%d}\n' "$((pass+fail))" "$pass" "$fail" > artifacts/qa-shell-results.json
+
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

**Type**: direct
**Ticket**: SPR-8 — AgentSandbox unattended workflow smoke 2026-03-19
**Priority**: P0

## Description

Created to validate unattended Linear -> dispatch -> AgentSandbox -> GitHub automation on kind. QA webhook retry at 2026-03-19T16:01Z.

## Agent Results

### Step 1: qa

Executed QA smoke validation checks for SPR-8, added a targeted shell-based test suite, and found 1 major mismatch: webhook retry timestamp in kind-workflow-smoke.txt is 2026-03-19T15:58Z instead of required 2026-03-19T16:01Z.

<details><summary>Files touched (5)</summary>

- `tests/workflow-smoke.qa.sh` (new)
- `artifacts/qa-shell-run.log` (new)
- `artifacts/qa-shell-results.json` (new)
- `artifacts/test-report.json` (new)
- `artifacts/bugs.md` (new)

</details>

**Issues**: Ticket SPR-8 requires QA webhook retry at 2026-03-19T16:01Z, but implementation records 2026-03-19T15:58Z in kind-workflow-smoke.txt.; No project stack/test framework was detected from .agent-context/stack.json (stack=unknown); executed targeted QA shell checks for available smoke artifacts.

### Step 901: developer

Fixed SPR-8 QA webhook retry marker timestamp by updating kind-workflow-smoke.txt to signature-retry 2026-03-19T16:01Z and refreshed QA artifacts after passing validation checks.

<details><summary>Files touched (7)</summary>

- `artifacts/handoff/dev-to-qa.md` (new)
- `kind-workflow-smoke.txt` (modified)
- `artifacts/qa-shell-results.json` (modified)
- `artifacts/qa-shell-run.log` (modified)
- `artifacts/test-report.json` (modified)
- `artifacts/bugs.md` (modified)
- `.agent-result.json` (modified)

</details>

### Step 1: qa

Validated branch feat/spr-8-agentsandbox-unattended-workflow-smoke-2026-03-19 by running the available smoke QA suite; all checks passed, including required webhook retry timestamp 2026-03-19T16:01Z.

<details><summary>Files touched (3)</summary>

- `artifacts/qa-shell-run.log` (modified)
- `artifacts/qa-shell-results.json` (modified)
- `.agent-result.json` (modified)

</details>

## Stats

| Metric | Value |
| --- | --- |
| Tokens used | 642,596 |
| Cost | $0.00 |
| Steps | 3 |
| Run ID | `run-1773936119102-9f9ae708` |

---
Generated by [SprintFoundry](https://github.com/Sagart-cactus/sprintfoundry)